### PR TITLE
Skip tests which require UTF-8 when it's not set

### DIFF
--- a/src/test/java/com/github/marschall/memoryfilesystem/UnixFileSystemComptiblityTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/UnixFileSystemComptiblityTest.java
@@ -14,9 +14,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -41,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -502,6 +505,7 @@ public class UnixFileSystemComptiblityTest {
      * Verifies that Linux does no Unicode normalization and that we can have
      * both a NFC and NFD file.
      */
+    assumeTrue(Charset.defaultCharset() == Charset.forName("UTF-8"));
     FileSystem fileSystem = this.getFileSystem();
     String aUmlaut = "\u00C4";
     Path nfcPath = fileSystem.getPath(aUmlaut);
@@ -539,6 +543,7 @@ public class UnixFileSystemComptiblityTest {
 
   @Test
   public void unixPaths() throws IOException {
+    assumeTrue(Charset.defaultCharset() == Charset.forName("UTF-8"));
     FileSystem fileSystem = this.getFileSystem();
     String aUmlaut = "\u00C4";
     String normalized = Normalizer.normalize(aUmlaut, Form.NFD);


### PR DESCRIPTION
Hi,

I am currently packaging memoryfilesystem for fedora. [Bugzilla is here](https://bugzilla.redhat.com/show_bug.cgi?id=1259851).
When building RPMs it is not possible to set LANG or LC_ALL to UTF-8. This patch can skip the tests which rely on properly set up UTF-8 when a different encoding is configured.

When you want to reproduce the failing test, just export LANG=C before you run the tests.

Best Regards,
Roman
