### PR TITLE
Do not hardcode schema version in spring xml files

### DIFF
--- a/src/test/resources/com/github/marschall/memoryfilesystem/MemoryFileSystemFactoryBeanTest-context-generated.xml
+++ b/src/test/resources/com/github/marschall/memoryfilesystem/MemoryFileSystemFactoryBeanTest-context-generated.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
   <bean id="memoryFileSystemFactory"

--- a/src/test/resources/com/github/marschall/memoryfilesystem/MemoryFileSystemFactoryBeanTest-context-windows.xml
+++ b/src/test/resources/com/github/marschall/memoryfilesystem/MemoryFileSystemFactoryBeanTest-context-windows.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:p="http://www.springframework.org/schema/p"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <bean id="memoryFileSystemFactory"
       class="com.github.marschall.memoryfilesystem.MemoryFileSystemFactoryBean"

--- a/src/test/resources/com/github/marschall/memoryfilesystem/MemoryFileSystemFactoryBeanTest-context.xml
+++ b/src/test/resources/com/github/marschall/memoryfilesystem/MemoryFileSystemFactoryBeanTest-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
 
   <bean id="memoryFileSystemFactory"


### PR DESCRIPTION
Another problem which I ran in during packaging:

When building packages for fedora, maven has no access to the internet and can't find the specified version of the schema. When removing the version from the filename, maven will automatically pick the newest version of the schema within its specified dependencies. See for instance [here](http://howtodoinjava.com/2013/12/28/do-not-specify-version-numbers-in-spring-schema-references/) for further details.

Best Regards,
Roman 