### PR TITLE
Removed a checkAccess(READ) while looking for file attributes

### DIFF
--- a/src/main/java/com/github/marschall/memoryfilesystem/MemoryEntry.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/MemoryEntry.java
@@ -230,7 +230,6 @@ abstract class MemoryEntry {
 
   <A extends FileAttributeView> A getFileAttributeView(Class<A> type) throws AccessDeniedException {
     try (AutoRelease lock = this.readLock()) {
-      this.checkAccess(AccessMode.READ);
       if (type == BasicFileAttributeView.class) {
         return (A) this.getBasicFileAttributeView();
       } else {

--- a/src/test/java/com/github/marschall/memoryfilesystem/PosixPermissionMemoryFileSystemTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/PosixPermissionMemoryFileSystemTest.java
@@ -118,6 +118,28 @@ public class PosixPermissionMemoryFileSystemTest {
   }
 
 
+  /**
+   * The owner should be able to read current permissions for its own file.
+   */
+  @Test
+  public void issue51() throws IOException {
+    Path path = this.rule.getFileSystem().getPath("readable-at-first");
+    Files.createFile(path,  PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("---------")));
+
+    assertFalse(Files.isReadable(path));
+    assertFalse(Files.isWritable(path));
+    assertFalse(Files.isExecutable(path));
+
+    Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-r--r--")); // FAIL.
+
+    assertTrue(Files.isReadable(path)); // ok
+    assertTrue(Files.isWritable(path)); // (should be) ok
+    assertFalse(Files.isExecutable(path)); // ok
+  }
+
+
+
+
   private static Set<PosixFilePermission> asSet(PosixFilePermission... permissions) {
     return new HashSet<>(Arrays.asList(permissions));
   }


### PR DESCRIPTION
Hello,

Right after fix of #50,  I tried it and got an error while calling `Files.setPermissions(Path, Set<PosixPermission>))`: the method `getFileAttributeView` was calling `checkAccess(READ)` to get a view.

I don't know if this is the right "patch" but::

1. In a way, it make sense to check that you can read the file (or rather its permissions). 
2. The `FileSystemProvider.getFileAttributeView(Path, Class<V>, LinkOption...)` API should always get the view because there is no indication of "possible error", apart from returning null for unsupported view. 
3. In the JDK, [UnixFileSystemProvider.java](http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/323b53b10644/src/solaris/classes/sun/nio/fs/UnixFileSystemProvider.java) invoke [UnixFileAttributeViews](http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/323b53b10644/src/solaris/classes/sun/nio/fs/UnixFileAttributeViews.java#l371) which create the object without further checks.

By the way, the stack trace with the check active:

``` 
java.nio.file.AccessDeniedException
	at com.github.marschall.memoryfilesystem.MemoryEntry$MemoryPosixFileAttributeView.checkAccess(MemoryEntry.java:810)
	at com.github.marschall.memoryfilesystem.MemoryEntry.checkAccess(MemoryEntry.java:168)
	at com.github.marschall.memoryfilesystem.MemoryEntry.getFileAttributeView(MemoryEntry.java:233)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem$8.value(MemoryFileSystem.java:633)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem$8.value(MemoryFileSystem.java:1)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem.withLockDo(MemoryFileSystem.java:766)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem.withReadLockDo(MemoryFileSystem.java:725)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem.accessFile(MemoryFileSystem.java:675)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem.accessFileReading(MemoryFileSystem.java:663)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem.getFileAttributeView(MemoryFileSystem.java:629)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem$LazyFileAttributeView.getView(MemoryFileSystem.java:1415)
	at com.github.marschall.memoryfilesystem.MemoryFileSystem$LazyFileAttributeView.invoke(MemoryFileSystem.java:1403)
	at com.sun.proxy.$Proxy5.setPermissions(Unknown Source)
	at java.nio.file.Files.setPosixFilePermissions(Files.java:2045)
	at com.github.marschall.memoryfilesystem.PosixPermissionMemoryFileSystemTest.issue51(PosixPermissionMemoryFileSystemTest.java:133)
	at  (junit)
```
