### PR TITLE
Make EmptyPath support getName and subpath

### DIFF
--- a/src/main/java/com/github/marschall/memoryfilesystem/EmptyPath.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/EmptyPath.java
@@ -42,12 +42,20 @@ final class EmptyPath extends ElementPath {
 
   @Override
   public Path getName(int index) {
-    throw new IllegalArgumentException("empty path does not support #getName(int)");
+    if (index == 0) {
+      return this;
+    } else {
+      throw new IllegalArgumentException("invalid index: " + index);
+    }
   }
 
   @Override
   public Path subpath(int beginIndex, int endIndex) {
-    throw new IllegalArgumentException("can't create a subpath on an empty path");
+    if (beginIndex == 0 && endIndex == 1) {
+      return this;
+    } else {
+      throw new IllegalArgumentException("invalid beginIndex, endIndex: " + beginIndex + ", " + endIndex);
+    }
   }
 
   @Override

--- a/src/test/java/com/github/marschall/memoryfilesystem/MemoryFileSystemTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/MemoryFileSystemTest.java
@@ -1169,10 +1169,12 @@ public class MemoryFileSystemTest {
     assertTrue(matcher instanceof RegexPathMatcher);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void emptySubPath() {
     FileSystem fileSystem = this.rule.getFileSystem();
-    assertEquals(fileSystem.getPath(""), fileSystem.getPath("").subpath(0, 0));
+    Path empty = fileSystem.getPath("");
+    assertEquals(1, empty.getNameCount());
+    assertEquals(empty, empty.subpath(0, 1));
   }
 
   @Test
@@ -1638,11 +1640,12 @@ public class MemoryFileSystemTest {
     usrBin.getName(2);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void emptyGetName() {
     FileSystem fileSystem = this.rule.getFileSystem();
     Path empty = fileSystem.getPath("");
-    empty.getName(0);
+    assertEquals(1, empty.getNameCount());
+    assertEquals(empty, empty.getName(0));
   }
 
   @Test


### PR DESCRIPTION
An EmptyPath returns 1 from getNameCount() and so should support
getName(0) and subpath(0, 1).

This is the empty path behavior of the default FileSystem on Oracle Java
SE 1.8.0_131 on macOS Sierra.