### PR TITLE
Change the Exception thrown by MemoryFileSystem.createFile

### DIFF
--- a/src/main/java/com/github/marschall/memoryfilesystem/MemoryFileSystem.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/MemoryFileSystem.java
@@ -473,7 +473,6 @@ class MemoryFileSystem extends FileSystem {
 
 
   void createDirectory(final AbstractPath path, final FileAttribute<?>... attrs) throws IOException {
-
     final FileAttribute<?>[] masked = this.applyUmask(attrs);
     this.createFile(path, new MemoryEntryCreator() {
 
@@ -551,7 +550,7 @@ class MemoryFileSystem extends FileSystem {
     this.checker.check();
     AbstractPath absolutePath = (AbstractPath) path.toAbsolutePath().normalize();
     if (absolutePath.isRoot()) {
-      throw new FileSystemException(path.toString(), null, "can not create root");
+      throw new FileAlreadyExistsException(path.toString(), null, "can not create root");
     }
     final ElementPath elementPath = (ElementPath) absolutePath;
     MemoryDirectory rootDirectory = this.getRootDirectory(elementPath);

--- a/src/test/java/com/github/marschall/memoryfilesystem/MemoryFileSystemTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/MemoryFileSystemTest.java
@@ -1825,6 +1825,14 @@ public class MemoryFileSystemTest {
   }
 
   @Test
+  public void createDirectoriesWithRoot() throws IOException {
+    FileSystem fileSystem = this.rule.getFileSystem();
+    Path root = fileSystem.getPath("/");
+    assertThat(root, exists());
+    assertEquals(Files.createDirectories(root), root);
+  }
+
+  @Test
   public void getRootDirectories() {
     FileSystem fileSystem = this.rule.getFileSystem();
     Iterator<Path> directories = fileSystem.getRootDirectories().iterator();


### PR DESCRIPTION
`Files::createDirectories` is coded in such a way that if we pass `fs.getPath("/foobar").getParent() `[which returns the root], it fails because it first invoke `Files::createDirectory` and except it to fails with a `FileAlreadyExistsException`, then check if the path point to a directory.

However, because the `MemoryFileSystem::createFile` method throws some `FileSystemException`, this does not work: `IOException` beside `FileAlreadyExistsException` are ignored, and in that case, the method looks for the path parent until it has access to it (eg: a directory) or it is `null`: in that case, it fails.

**Note:** it might seems strange to create a directory on the root, but this happened during a change of JSR 203 implementation (I was using JimFS and that [was it does](https://github.com/google/jimfs/blob/3299e69f75cf524e6d101d88e8c202c1b24bf25a/jimfs/src/main/java/com/google/common/jimfs/FileSystemView.java)): in a test, I was creating a file using a relative path which resolved to `/file1`. The code was trying to create intermediate directories and it failed in memoryfs because of how `Files::createDirectories` is coded. 

I don't say that JimFS is the "truth" nor that MemoryFS is wrong (the Javadoc for   `FileSystemProvider.createDirectory` state that the `FileAlreadyExistsException` is an _optional specific exception_) but I think it is right to think about the roots as already existing (which was already tested by MemoryFS by the way).
