### PR TITLE
Feature/fix build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-toolchains-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.7</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <log4j.version>2.11.0</log4j.version>
     <spring.version>4.3.18.RELEASE</spring.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20.1</version>
+          <version>2.21.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
I had some trouble to build this project with JDK 10.0.2.

The first problem was with the maven-compiler-plugin:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.559 s
[INFO] Finished at: 2018-08-14T07:53:18+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project memoryfilesystem: Compilation failure: Compilation failure:
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
```

Setting the properties `maven.compiler.source` and `maven.compiler.target` to `1.7` solved it. I'm not sure  if or how these properties interact with your executions of the compiler plugin.

The second problem was caused by a bug in the maven-surefire-plugin when JDK 10 is used. See 
https://issues.apache.org/jira/browse/SUREFIRE-1439 for details.

The version update of the compiler plugin is unrelated. Version 3.8.0 bumps the default Java version from 1.5 to 1.6.