### PR TITLE
Use java.time.Instant to store time information in MemoryFileAttributes

### DIFF
--- a/src/main/java/com/github/marschall/memoryfilesystem/MemoryEntryAttributes.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/MemoryEntryAttributes.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.PosixFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
 import java.nio.file.attribute.UserPrincipal;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -46,9 +47,9 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 abstract class MemoryEntryAttributes {
 
   // protected by read and write locks
-  private long lastModifiedTime;
-  private long lastAccessTime;
-  private long creationTime;
+  private Instant lastModifiedTime;
+  private Instant lastAccessTime;
+  private Instant creationTime;
 
   private final Map<String, InitializingFileAttributeView> additionalViews;
 
@@ -61,7 +62,7 @@ abstract class MemoryEntryAttributes {
     this.basicFileAttributeView = this.newBasicFileAttributeView();
     this.fileSystem = context.fileSystem;
     this.lock = new ReentrantReadWriteLock();
-    long now = this.getNow();
+    Instant now = this.getNow();
     this.lastAccessTime = now;
     this.lastModifiedTime = now;
     this.creationTime = now;
@@ -95,19 +96,19 @@ abstract class MemoryEntryAttributes {
   }
 
   FileTime lastModifiedTime() {
-    return FileTime.fromMillis(this.lastModifiedTime);
+    return FileTime.from(this.lastModifiedTime);
   }
 
   FileTime lastAccessTime() {
-    return FileTime.fromMillis(this.lastAccessTime);
+    return FileTime.from(this.lastAccessTime);
   }
 
   FileTime creationTime() {
-    return FileTime.fromMillis(this.creationTime);
+    return FileTime.from(this.creationTime);
   }
 
-  long getNow() {
-    return System.currentTimeMillis();
+  Instant getNow() {
+    return Instant.now();
   }
 
   private UserPrincipal getCurrentUser() {
@@ -158,7 +159,7 @@ abstract class MemoryEntryAttributes {
 
   void modified() {
     // No write lock because this was to be folded in an operation with a write lock
-    long now = this.getNow();
+    Instant now = this.getNow();
     this.lastAccessTime = now;
     this.lastModifiedTime = now;
   }
@@ -172,13 +173,13 @@ abstract class MemoryEntryAttributes {
     try (AutoRelease lock = this.writeLock()) {
       this.checkAccess(AccessMode.WRITE);
       if (lastModifiedTime != null) {
-        this.lastModifiedTime = lastModifiedTime.toMillis();
+        this.lastModifiedTime = lastModifiedTime.toInstant();
       }
       if (lastAccessTime != null) {
-        this.lastAccessTime = lastAccessTime.toMillis();
+        this.lastAccessTime = lastAccessTime.toInstant();
       }
       if (createTime != null) {
-        this.creationTime = createTime.toMillis();
+        this.creationTime = createTime.toInstant();
       }
     }
   }

--- a/src/test/java/com/github/marschall/memoryfilesystem/MemoryEntryTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/MemoryEntryTest.java
@@ -8,6 +8,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -63,5 +64,29 @@ class MemoryEntryTest {
     assertEquals(cTime, attributes.creationTime());
     assertEquals(mTime, attributes.lastModifiedTime());
     assertEquals(aTime, attributes.lastAccessTime());
+  }
+
+  @ParameterizedTest(name = DISPLAY_NAME)
+  @MethodSource("data")
+  void instant(MemoryEntry memoryEntry) throws IOException {
+    Instant creationTime = Instant.parse("2019-01-28T01:02:03.046Z");
+    Instant lastModificationTime = Instant.parse("2019-01-28T01:02:03.123456Z");
+    Instant lastAccessTime = Instant.parse("2019-01-28T01:02:03.123456789Z");
+
+    BasicFileAttributeView view = memoryEntry.getBasicFileAttributeView();
+    FileTime mTime = FileTime.from(lastModificationTime);
+    FileTime aTime = FileTime.from(lastAccessTime);
+    FileTime cTime = FileTime.from(creationTime);
+    view.setTimes(mTime, aTime, cTime);
+
+    BasicFileAttributes attributes = view.readAttributes();
+    assertEquals(cTime, attributes.creationTime());
+    assertEquals(mTime, attributes.lastModifiedTime());
+    assertEquals(aTime, attributes.lastAccessTime());
+
+    // check that we keep the granularity (eg: to the nano).
+    assertEquals(cTime.toInstant().getNano(), creationTime.getNano());
+    assertEquals(mTime.toInstant().getNano(), lastModificationTime.getNano());
+    assertEquals(aTime.toInstant().getNano(), lastAccessTime.getNano());
   }
 }


### PR DESCRIPTION
The use of Instant intead of long + FileTime.toMillis/fromMillis keep the granularity (for example, up to the nanoseconds if the fs supports it).