### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>--add-opens com.github.marschall.memoryfilesystem/com.github.marschall.memoryfilesystem=ALL-UNNAMED</argLine>
-          	<disableXmlReport>${closeTestReports}</disableXmlReport>
+          	  <disableXmlReport>${closeTestReports}</disableXmlReport>
             </configuration>
           </plugin>
         </plugins>
@@ -517,7 +517,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <useModulePath>false</useModulePath>
-          	<disableXmlReport>${closeTestReports}</disableXmlReport>
+          	  <disableXmlReport>${closeTestReports}</disableXmlReport>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>--add-opens com.github.marschall.memoryfilesystem/com.github.marschall.memoryfilesystem=ALL-UNNAMED</argLine>
+          	<disableXmlReport>${closeTestReports}</disableXmlReport>
             </configuration>
           </plugin>
         </plugins>
@@ -516,6 +517,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <useModulePath>false</useModulePath>
+          	<disableXmlReport>${closeTestReports}</disableXmlReport>
             </configuration>
           </plugin>
         </plugins>
@@ -526,6 +528,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
 </project>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
