### PR TITLE
Only support URL handling for the 'memory' scheme

### DIFF
--- a/src/main/java/com/github/marschall/memoryfilesystem/memory/Handler.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/memory/Handler.java
@@ -1,5 +1,7 @@
 package com.github.marschall.memoryfilesystem.memory;
 
+import com.github.marschall.memoryfilesystem.MemoryFileSystemProvider;
+
 import java.net.Proxy;
 import java.net.URL;
 import java.net.URLConnection;
@@ -31,6 +33,14 @@ public class Handler extends URLStreamHandler {
     if (url == null) {
       throw new IllegalArgumentException("url was null");
     }
+
+    String protocol = url.getProtocol();
+
+    if (!MemoryFileSystemProvider.SCHEME.equals(protocol)) {
+      throw new UnsupportedOperationException("Cannot use protocol '"
+          + protocol + "' for this implementation");
+    }
+
     return new MemoryURLConnection(url);
   }
 

--- a/src/main/java/com/github/marschall/memoryfilesystem/memory/MemoryURLConnection.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/memory/MemoryURLConnection.java
@@ -1,5 +1,7 @@
 package com.github.marschall.memoryfilesystem.memory;
 
+import com.github.marschall.memoryfilesystem.MemoryFileSystemProvider;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -17,6 +19,13 @@ final class MemoryURLConnection extends URLConnection {
 
   MemoryURLConnection(URL url) {
     super(url);
+
+    String protocol = url.getProtocol();
+
+    if (!MemoryFileSystemProvider.SCHEME.equals(protocol)) {
+      throw new UnsupportedOperationException("Cannot use protocol '"
+          + protocol + "' for this implementation");
+    }
   }
 
   @Override
@@ -81,5 +90,4 @@ final class MemoryURLConnection extends URLConnection {
       return 0L;
     }
   }
-
 }

--- a/src/main/java/com/github/marschall/memoryfilesystem/memory/MemoryURLStreamHandlerFactory.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/memory/MemoryURLStreamHandlerFactory.java
@@ -1,5 +1,7 @@
 package com.github.marschall.memoryfilesystem.memory;
 
+import com.github.marschall.memoryfilesystem.MemoryFileSystemProvider;
+
 import java.net.URL;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
@@ -18,7 +20,9 @@ public final class MemoryURLStreamHandlerFactory implements URLStreamHandlerFact
 
   @Override
   public URLStreamHandler createURLStreamHandler(String protocol) {
-    return new Handler();
+    return MemoryFileSystemProvider.SCHEME.equals(protocol)
+        ? new Handler()
+        : null;
   }
 
 }

--- a/src/test/java/com/github/marschall/memoryfilesystem/UrlTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/UrlTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -12,7 +13,9 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.UUID;
 
+import com.github.marschall.memoryfilesystem.memory.MemoryURLStreamHandlerFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -92,4 +95,13 @@ class UrlTest {
     assertThrows(IOException.class, urlConnection::connect);
   }
 
+  @Test
+  void doNotSupportArbitraryProtocolsForHandlerFactory() {
+    String someDefaultProtocol = "file";
+    String someMissingProtocol = UUID.randomUUID().toString();
+    MemoryURLStreamHandlerFactory factory = new MemoryURLStreamHandlerFactory();
+
+    assertNull(factory.createURLStreamHandler(someDefaultProtocol));
+    assertNull(factory.createURLStreamHandler(someMissingProtocol));
+  }
 }


### PR DESCRIPTION
Just a quick one off the back of what was added earlier today.

Looks like the current implementation will allow itself to be initialised with any form of protocol. Right now, I can see that initialising a URL with a protocol of "some-crazy-random-scheme" gets assigned to the `Handler` class in this module, rather than it throwing an Exception about it.

![image](https://user-images.githubusercontent.com/73482956/236684450-ab54fc05-9345-4167-ad98-269bf82900f4.png)

I've added some additional checks to try and help avoid this, especially since this can occur implicitly if using the Java 9 SPI for the URL handler factory.

Upon performing these checks, the behaviour changes to the expected outcome:

```
java.net.MalformedURLException: unknown protocol: some-crazy-random-scheme
	at java.base/java.net.URL.<init>(URL.java:682)
	at java.base/java.net.URL.fromURI(URL.java:749)
	at java.base/java.net.URI.toURL(URI.java:1136)
	... 58 more
```