### PR TITLE
Ensure directory URLs end in a forward slash

### DIFF
--- a/src/test/java/com/github/marschall/memoryfilesystem/PosixPermissionMemoryFileSystemTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/PosixPermissionMemoryFileSystemTest.java
@@ -342,7 +342,8 @@ class PosixPermissionMemoryFileSystemTest {
   @Test
   void issue138() throws IOException {
     try (FileSystem fs = MemoryFileSystemBuilder.newLinux().build()) {
-      Path path = fs.getPath("/home/marschall/a.csv");
+
+      Path path = fs.getPath(System.getProperty("user.home") + "/a.csv");
       Files.createFile(path);
 
       PosixFileAttributeView fileAttributeView = Files.getFileAttributeView(path, PosixFileAttributeView.class);


### PR DESCRIPTION
This fixes the issue that I mentioned at the end of https://github.com/marschall/memoryfilesystem/issues/142#issuecomment-1537474690

ClassLoaders are getting a bit confused with the URLs being provided. By the looks, URLs that represent a directory are being expected to be passed back with a trailing backslash to denote that they are directories. It doesn't look like MemoryFileSystem is doing that implicitly though, which is leading the JDK classloader logic to consider the URLs being provided as being for a JAR rather than a file system tree.

Code that seems to be triggering the issue on the JDK side is at https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java#L471.

The result on the ClassLoader level appears to be

```
java.lang.ClassNotFoundException: org.example.User
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:445)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at org.codehaus.groovy.vmplugin.v8.IndyInterface.fromCache(IndyInterface.java:321)
```

Fixes feedback in GH-142

Can confirm that with this, URL class loading is working for me perfectly (along with a work-around for #144 on my side)

![image](https://user-images.githubusercontent.com/73482956/236800941-07c812ea-16b9-424c-a2a3-fda5d2512b93.png)
