### PR TITLE
feat: `newDirectoryStream` follows symlinks

### DIFF
--- a/src/main/java/com/github/marschall/memoryfilesystem/MemoryFileSystem.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/MemoryFileSystem.java
@@ -478,7 +478,7 @@ class MemoryFileSystem extends FileSystem implements FileSystemContext {
   }
 
   DirectoryStream<Path> newDirectoryStream(final AbstractPath abstractPath, final Filter<? super Path> filter) throws IOException {
-    return this.accessFileReading(abstractPath, false,  entry -> {
+    return this.accessFileReading(abstractPath, true,  entry -> {
       if (!(entry instanceof MemoryDirectory)) {
         throw new NotDirectoryException(abstractPath.toString());
       }

--- a/src/test/java/com/github/marschall/memoryfilesystem/MemoryDirectoryStreamTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/MemoryDirectoryStreamTest.java
@@ -128,6 +128,35 @@ class MemoryDirectoryStreamTest {
   }
 
   @Test
+  void directoryStreamFollowsSymlink() throws IOException {
+    FileSystem fileSystem = this.extension.getFileSystem();
+
+    Path root = fileSystem.getRootDirectories().iterator().next();
+    Path volumes = Files.createDirectory(root.resolve("Volumes"));
+    Path hd = Files.createSymbolicLink(volumes.resolve("Macintosh HD"), root);
+
+    Path abc = Files.createFile(root.resolve("abc.txt"));
+
+    try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(hd)) {
+      List<String> actual = new ArrayList<>(2);
+      for (Path each : directoryStream) {
+        actual.add(each.toRealPath().toString());
+      }
+      List<String> expected = Arrays.asList(
+          volumes.toRealPath().toString(),
+          abc.toRealPath().toString()
+      );
+      assertEquals(expected.size(), actual.size());
+
+      Set<String> actualSet = new HashSet<>(actual);
+      assertEquals(actualSet.size(), actual.size());
+
+      Set<String> expectedSet = new HashSet<>(expected);
+      assertEquals(expectedSet, actualSet);
+    }
+  }
+
+  @Test
   void empty() throws IOException {
     FileSystem fileSystem = this.extension.getFileSystem();
 


### PR DESCRIPTION
The PR allows `newDirectoryStream` to follow symbolic links when the target of the link is a directory. The change helps the library to behave like the java implementations of Filesystem.

As an example:
```
/
/Volumes
/Volumes/Macintosh HD (symlink to /)
/somefile.txt
```
Files.newDirectoryStream() for `/Volumes/Macintosh HD` should return `Volumes` and `somefile.txt`