### PR TITLE
Fix failing Maven build on Windows and improve nested ZIP tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -360,7 +360,7 @@
       </plugins>
     </pluginManagement>
   </build>
-  
+
   <reporting>
     <excludeDefaults>true</excludeDefaults>
     <plugins>
@@ -433,7 +433,7 @@
             <configuration>
               <name>com.github.marschall.memoryfilesystem</name>
               <exports>com.github.marschall.memoryfilesystem,com.github.marschall.memoryfilesystem.memory</exports>
-              <static-requires>java.annotation,jakarta.annotation</static-requires>
+              <static-requires>java.annotation,jakarta.annotation,java.prefs</static-requires>
               <provides>
                 <provide>
                   <services>java.nio.file.spi.FileSystemProvider</services>

--- a/src/test/java/com/github/marschall/memoryfilesystem/AdminChecker.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/AdminChecker.java
@@ -1,0 +1,41 @@
+package com.github.marschall.memoryfilesystem;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.prefs.Preferences;
+
+/**
+ * Checks if the current user is the local administrator
+ * <p>
+ * Adapted from <a href="https://stackoverflow.com/a/23538961/1082681">this Stack Overflow answer</a>.
+ */
+public class AdminChecker {
+  public static final boolean IS_ADMIN = isRunningAsAdministrator();
+
+  private static boolean isRunningAsAdministrator() {
+    Preferences systemPrefs = Preferences.systemRoot();
+    synchronized (System.err) {
+      PrintStream stdErrOriginal = System.err;
+      try (PrintStream stdErrMock = new PrintStream(new MockOutputStream())) {
+        System.setErr(stdErrMock);
+        try {
+          systemPrefs.put("foo", "bar"); // SecurityException on Windows
+          systemPrefs.remove("foo");
+          systemPrefs.flush(); // BackingStoreException on Linux
+          return true;
+        }
+        catch (Exception exception) {
+          return false;
+        }
+      }
+      finally {
+        System.setErr(stdErrOriginal);
+      }
+    }
+  }
+
+  private static class MockOutputStream extends OutputStream {
+    @Override
+    public void write(int b) {}
+  }
+}

--- a/src/test/java/com/github/marschall/memoryfilesystem/FileSystemCompatibilityTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/FileSystemCompatibilityTest.java
@@ -40,7 +40,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -277,6 +279,10 @@ class FileSystemCompatibilityTest {
 
   @CompatibilityTest
   void newDirectoryStreamFollowSymlinks(boolean useDefault) throws IOException {
+    Assumptions.assumeFalse(
+      useDefault && OS.current().equals(OS.WINDOWS),
+      "skip symbolic link test on Windows default file system"
+    );
     FileSystem fileSystem = this.getFileSystem(useDefault);
     Path target = fileSystem.getPath("target");
     if (!useDefault) {
@@ -326,6 +332,11 @@ class FileSystemCompatibilityTest {
 
   @CompatibilityTest
   void relativeSymlinks(boolean useDefault) throws IOException {
+    Assumptions.assumeFalse(
+      useDefault && OS.current().equals(OS.WINDOWS),
+      "skip symbolic link test on Windows default file system"
+    );
+
     FileSystem fileSystem = this.getFileSystem(useDefault);
     Path target = fileSystem.getPath("target");
     if (!useDefault) {

--- a/src/test/java/com/github/marschall/memoryfilesystem/FileSystemCompatibilityTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/FileSystemCompatibilityTest.java
@@ -280,8 +280,8 @@ class FileSystemCompatibilityTest {
   @CompatibilityTest
   void newDirectoryStreamFollowSymlinks(boolean useDefault) throws IOException {
     Assumptions.assumeFalse(
-      useDefault && OS.current().equals(OS.WINDOWS),
-      "skip symbolic link test on Windows default file system"
+      useDefault && OS.current().equals(OS.WINDOWS) && !AdminChecker.IS_ADMIN,
+      "skip symbolic link test on Windows default file system, if not admin"
     );
     FileSystem fileSystem = this.getFileSystem(useDefault);
     Path target = fileSystem.getPath("target");
@@ -333,8 +333,8 @@ class FileSystemCompatibilityTest {
   @CompatibilityTest
   void relativeSymlinks(boolean useDefault) throws IOException {
     Assumptions.assumeFalse(
-      useDefault && OS.current().equals(OS.WINDOWS),
-      "skip symbolic link test on Windows default file system"
+      useDefault && OS.current().equals(OS.WINDOWS) && !AdminChecker.IS_ADMIN,
+      "skip symbolic link test on Windows default file system, if not admin"
     );
 
     FileSystem fileSystem = this.getFileSystem(useDefault);


### PR DESCRIPTION
### Fix failing Maven build on Windows

Two parametrised test iterations using symlinks on native file systems were failing on Windows, because there we do not have UNIX-style symlinks. Skipping the whole test using `@DisabledOnOs` would have been an option, but a suboptimal one, because then the iteration testing symlinks on the in-memory FS would also have been skipped. Therefore, an assumption is used:

```java
Assumptions.assumeFalse(
  useDefault && OS.current().equals(OS.WINDOWS),
  "skip symbolic link test on Windows default file system"
);
```

### Conditionally enable nested zip tests depending on JDK version

Since JDK 12, `ZipFileSystem` technically supports nested zips, albeit only when using Path, not URI parameters. The corresponding OpenJDK commit is https://github.com/openjdk/jdk/commit/196c20c0d1.

Unfortunately, only since JDK 13 there is an overloaded method `FileSystems.newFileSystem(Path, Map)`, which also permits to create a new nested JAR. In order to stay JDK 8 compatible, however, we cannot use that method. Hence, the tests still use the workaround to create empty zip files via `JarOutputStream`. But at least it works, and we can conditionally enable two more tests using:

```java
@EnabledForJreRange(min = JRE.JAVA_12)
```

One more test involving URIs for files inside zip files (non-nested ones only!) can be activated as of JDK 9+, because the problem was fixed since then.

The build now passes on JDKs 8 to 21, always executing as many tests as possible.

Relates to #156.