### PR TITLE
Fix #161 and #160. Handle open file restrictions during move and delete

### DIFF
--- a/src/main/java/com/github/marschall/memoryfilesystem/MemoryFileSystem.java
+++ b/src/main/java/com/github/marschall/memoryfilesystem/MemoryFileSystem.java
@@ -125,6 +125,8 @@ class MemoryFileSystem extends FileSystem implements FileSystemContext {
 
   private final boolean supportFileChannelOnDirectory;
 
+  private static final String DEVICE_OR_RESOURCE_BUSY_MESSAGE = "Device or resource busy.";
+
   static {
     Set<String> unsupported = new HashSet<>(3);
     unsupported.add("lastAccessTime");
@@ -1174,7 +1176,7 @@ class MemoryFileSystem extends FileSystem implements FileSystemContext {
           if (child instanceof MemoryFile) {
             MemoryFile file = (MemoryFile) child;
             if (file.openCount() > 0) {
-              throw new FileSystemException(abstractPath.toString(), null, "file still open");
+              throwResourceBusyException(abstractPath);
             }
             file.markForDeletion();
           }
@@ -1208,7 +1210,7 @@ class MemoryFileSystem extends FileSystem implements FileSystemContext {
             if (child instanceof MemoryFile) {
               MemoryFile file = (MemoryFile) child;
               if (file.openCount() > 0) {
-                throw new FileSystemException(abstractPath.toString(), null, "file still open");
+                throwResourceBusyException(abstractPath);
               }
               file.markForDeletion();
             }
@@ -1472,6 +1474,12 @@ class MemoryFileSystem extends FileSystem implements FileSystemContext {
     }
 
     if (copyContext.operation.isMove()) {
+      if (sourceEntry instanceof MemoryFile) {
+        MemoryFile sourceFile = (MemoryFile) sourceEntry;
+        if (sourceFile.openCount() > 0) {
+          throwResourceBusyException(copyContext.source.path);
+        }
+      }
       sourceParent.removeEntry(sourceElementName);
       targetParent.addEntry(targetElementName, sourceEntry, copyContext.target.path);
       String newOriginalName = targetContext.path.getMemoryFileSystem().storeTransformer.transform(targetContext.elementName);
@@ -1503,6 +1511,10 @@ class MemoryFileSystem extends FileSystem implements FileSystemContext {
       toCopy = sourceEntry;
     }
     return toCopy;
+  }
+
+  private static void throwResourceBusyException(AbstractPath abstractPath) throws FileSystemException {
+    throw new FileSystemException(abstractPath.toString(), null, DEVICE_OR_RESOURCE_BUSY_MESSAGE);
   }
 
   @Override

--- a/src/test/java/com/github/marschall/memoryfilesystem/MemoryFileSystemTest.java
+++ b/src/test/java/com/github/marschall/memoryfilesystem/MemoryFileSystemTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
@@ -888,8 +889,10 @@ class MemoryFileSystemTest {
     FileSystem fileSystem = this.extension.getFileSystem();
     Path path = fileSystem.getPath("test");
     try (SeekableByteChannel channel = Files.newByteChannel(path, CREATE_NEW, WRITE)) {
-      assertThrows(FileSystemException.class , () -> Files.delete(path), "you shound't be able to delete a file wile it's open");
-      assertThrows(FileSystemException.class , () -> Files.deleteIfExists(path), "you shound't be able to delete a file wile it's open");
+      FileSystemException deleteException = assertThrows(FileSystemException.class , () -> Files.delete(path), "you shouldn't be able to delete a file while it's open");
+      assertThat(deleteException.getMessage(), is(path + ": Device or resource busy."));
+      FileSystemException deleteIfExistsException = assertThrows(FileSystemException.class , () -> Files.deleteIfExists(path), "you shouldn't be able to delete a file while it's open");
+      assertThat(deleteIfExistsException.getMessage(), is(path + ": Device or resource busy."));
     }
   }
 


### PR DESCRIPTION
Introduce a helper method to throw consistent "resource busy" exceptions for open files. Add logic to prevent moving open files and refine handling of delete attempts on open files. Include corresponding test cases to verify the behavior.